### PR TITLE
feat: Allow to enable breadcrumbs for Raven client.

### DIFF
--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -12,9 +12,9 @@ class SentryMiddleware:
 
         sentry_kwargs = {
             'transport': raven_aiohttp.AioHttpTransport,
-            'enable_breadcrumbs': False,
             **sentry_kwargs,
         }
+        sentry_kwargs.setdefault('enable_breadcrumbs', False)
         self.client = raven.Client(**sentry_kwargs)
 
     async def __call__(self, app, handler):


### PR DESCRIPTION
Previously `enable_breadcrumbs` was set to `False` in `sentry_kwargs`
without ability its redefine. Fixes that and allow user to control
this `raven.Client` kwarg.

Issue: #4