### PR TITLE
Install a modified sys.excepthook which closes Sentry transport

### DIFF
--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -46,6 +46,9 @@ class SentryMiddleware:
                     loop = asyncio.get_event_loop()
                 # wait for Sentry transport to send the outstanding messages
                 loop.run_until_complete(transport.close())
+            # the idea of using the original excepthook
+            # was taken from raven-python repository:
+            # https://github.com/getsentry/raven-python/blob/f6d79c3bcc25e804b6259fa9c4a6e030f9033bb2/raven/base.py#L280
             original_excepthook(*exc_info)
 
         sys.excepthook = aiohttp_transport_excepthook

--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -12,13 +12,11 @@ class SentryMiddleware:
         if sentry_kwargs is None:
             sentry_kwargs = {}
 
-        if install_excepthook:
-            # do not let raven.Client install its own excepthook
-            sentry_kwargs['install_sys_hook'] = False
-
         sentry_kwargs = {
             'transport': raven_aiohttp.AioHttpTransport,
             'enable_breadcrumbs': False,
+            # by default, do not let raven.Client install its own excepthook
+            'install_sys_hook': not install_excepthook,
             **sentry_kwargs,
         }
         self.client = raven.Client(**sentry_kwargs)

--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -8,7 +8,7 @@ import raven_aiohttp
 
 class SentryMiddleware:
 
-    def __init__(self, install_excepthook=True, sentry_kwargs=None):
+    def __init__(self, sentry_kwargs=None, *, install_excepthook=True):
         if sentry_kwargs is None:
             sentry_kwargs = {}
 

--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -8,12 +8,12 @@ import raven_aiohttp
 
 class SentryMiddleware:
 
-    def __init__(self, sentry_kwargs=None):
+    def __init__(self, install_excepthook=True, sentry_kwargs=None):
         if sentry_kwargs is None:
             sentry_kwargs = {}
 
-        if sentry_kwargs.get('install_sys_hook'):
-            install_excepthook = True
+        if install_excepthook:
+            # do not let raven.Client install its own excepthook
             sentry_kwargs['install_sys_hook'] = False
 
         sentry_kwargs = {

--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -42,10 +42,11 @@ class SentryMiddleware:
             self.client.captureException(exc_info=exc_info, level='fatal')
             transport = self.client.remote.get_transport()
             if isinstance(transport, raven_aiohttp.AioHttpTransportBase):
-                if loop is None:
-                    loop = asyncio.get_event_loop()
+                event_loop = loop
+                if event_loop is None:
+                    event_loop = asyncio.get_event_loop()
                 # wait for Sentry transport to send the outstanding messages
-                loop.run_until_complete(transport.close())
+                event_loop.run_until_complete(transport.close())
             # the idea of using the original excepthook
             # was taken from raven-python repository:
             # https://github.com/getsentry/raven-python/blob/f6d79c3bcc25e804b6259fa9c4a6e030f9033bb2/raven/base.py#L280


### PR DESCRIPTION
The default `sys.excepthook` installed by `raven.Client` when `install_sys_hook` is `True` does not wait for the currently used transport (`raven_aiohttp.AioHttpTransport`) to finish sending its outstanding messages. As a result, some of the exceptions might not get reported into Sentry when `sys.excepthook` is used.

This MR aims to update the configured `sys.excepthook`, so that it would close the `raven_aiohttp.AioHttpTransport` before exiting the application.