### PR TITLE
fix transport is None when calling ensure_future

### DIFF
--- a/aiohttp_sentry/__init__.py
+++ b/aiohttp_sentry/__init__.py
@@ -32,7 +32,7 @@ class SentryMiddleware:
                     'url': request.path,
                     'method': request.method,
                     'env': {
-                        'REMOTE_ADDR': request.transport.get_extra_info('peername')[0],
+                        'REMOTE_ADDR': request.transport.get_extra_info('peername')[0] if request.transport else 'unknown',
                     }
                 }
             })


### PR DESCRIPTION
When we  use the ensure_future to call handler, like this:
```
async def task_middleware(app, handler):
    # This middleware should be ahead of babel middleware
    async def task_handler(request):
        task = asyncio.ensure_future(handler(request), loop=app.loop)
        await task
        return task.result()
    return task_handler
```
It will raise an error:
```
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp_sentry/__init__.py", line 25, in middleware
    return await handler(request)
  File "/home/user/xxxx/middleware/common.py", line 54, in task_handler
    await task
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/asyncio/futures.py", line 266, in result
    raise CancelledError
concurrent.futures._base.CancelledError


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp/web_protocol.py", line 422, in start
    resp = yield from self._request_handler(request)
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp/web.py", line 306, in _handle
    resp = yield from handler(request)
  File "/home/user/.pyenv/versions/3.5.2/lib/python3.5/site-packages/aiohttp_sentry/__init__.py", line 35, in middleware
    'REMOTE_ADDR': request.transport.get_extra_info('peername')[0],
AttributeError: 'NoneType' object has no attribute 'get_extra_info'
```
In case of  `CancelledError`, we cannot get remote_addr in request.transport